### PR TITLE
harmonise curve names with RFC 5656

### DIFF
--- a/draft-ssorce-gss-keyex-sha2.xml
+++ b/draft-ssorce-gss-keyex-sha2.xml
@@ -210,7 +210,7 @@
         <t>1. C generates an ephemeral key pair with public key Q_C. It does
             that by:
           <list>
-            <t>For secp curves:
+            <t>For NIST curves:
               <list>
                 <t>Selecting a value d_C uniformly at random from the interval
                     [1, n-1] where n is the order of generator of the curve
@@ -221,7 +221,7 @@
                     concatenation of value 0x04 and big-endian representation
                     of the x coordinate and then y coordinate. The coordinate
                     coversion MUST preserve leading zero octets. Thus for
-                    secp521r1 curve the encoded x coordinate will always have a
+                    nistp521 curve the encoded x coordinate will always have a
                     length of 66 octets while the Q_C representation will be
                     133 octets long. This is the uncompressed representation
                     specified in Section 4.3.6 of
@@ -294,21 +294,21 @@
         If the key is not valid the key exchange MUST fail.</t>
         </list>
             <t>The server first checks if the length of the Q_C matches the
-                selected key exchange: 65 octets for secp256r1, 97 octets for
-                secp384r1, 133 octets for secp521r1, 32 octets for curve25519
+                selected key exchange: 65 octets for nistp256, 97 octets for
+                nistp384, 133 octets for nistp521, 32 octets for curve25519
                 or 56 octets for curve448. If the value does not have matching
                 length the key exchange MUST fail.</t>
-            <t>In case of key exchanges that use secp curves, the server MUST
+            <t>In case of key exchanges that use NIST curves, the server MUST
                 check if the first octet of the Q_C is equal to 0x04.
                 If the octet has different value the key exchange MUST fail.
             </t>
-            <t>For secp curves, the server converts the octet representation of
+            <t>For NIST curves, the server converts the octet representation of
                 the key to q_C point representation by interpreting the first
                 half of remaining octets as the unsigned big-endian
                 representation of the x coordinate of the point and the second
                 half as the unsigned big-endian representation of the y
                 coordinate.</t>
-            <t>For secp curves, the server verifies that the q_C is not a point
+            <t>For NIST curves, the server verifies that the q_C is not a point
                 at infinity, that both coordinates are in the interval
                 [0, p - 1], where p is the prime associated with the curve of
                 the selected key exchange and that the point lies on the curve
@@ -357,12 +357,12 @@
                   d_U is the secret value, d_C for client and d_S for server
                   and q_V is the received public value, q_S for client and q_C
                   for server.</t>
-              <t>For secp curves, the peers perform point multiplication using
+              <t>For NIST curves, the peers perform point multiplication using
                   d_U and q_V to get point P.</t>
-              <t>For secp curves, peers verify that P is not a point at
+              <t>For NIST curves, peers verify that P is not a point at
                   infinity. If P is a point at infinity, the key exchange
                   MUST fail.</t>
-              <t>For secp curves, the shared secret is the zero-padded
+              <t>For NIST curves, the shared secret is the zero-padded
                   big-endian representation of the x coordinate of P.</t>
               <t>For curve25519 and curve448, the peers apply the X25519 or
                   X448 function, respectively for curve25519 and curve448,
@@ -519,9 +519,9 @@
         </preamble>
           <ttcol align="left">Key Exchange Method Name</ttcol>
           <ttcol align="left">Implementation Recommendations</ttcol>
-          <c>gss-secp256r1-sha256-*</c><c>SHOULD/RECOMMENDED</c>
-          <c>gss-secp384r1-sha512-*</c><c>MAY/OPTIONAL</c>
-          <c>gss-secp521r1-sha512-*</c><c>MAY/OPTIONAL</c>
+          <c>gss-nistp256-sha256-*</c><c>SHOULD/RECOMMENDED</c>
+          <c>gss-nistp384-sha512-*</c><c>MAY/OPTIONAL</c>
+          <c>gss-nistp521-sha512-*</c><c>MAY/OPTIONAL</c>
           <c>gss-curve25519-sha256-*</c><c>SHOULD/RECOMMENDED</c>
           <c>gss-curve448-sha512-*</c><c>MAY/OPTIONAL</c>
       </texttable>
@@ -546,9 +546,9 @@
           <c>gss-group16-sha512-*</c><c>This draft</c><c>SHOULD</c>
           <c>gss-group17-sha512-*</c><c>This draft</c><c>MAY</c>
           <c>gss-group18-sha512-*</c><c>This draft</c><c>MAY</c>
-          <c>gss-secp256r1-sha256-*</c><c>This draft</c><c>SHOULD</c>
-          <c>gss-secp384r1-sha512-*</c><c>This draft</c><c>MAY</c>
-          <c>gss-secp521r1-sha512-*</c><c>This draft</c><c>MAY</c>
+          <c>gss-nistp256-sha256-*</c><c>This draft</c><c>SHOULD</c>
+          <c>gss-nistp384-sha512-*</c><c>This draft</c><c>MAY</c>
+          <c>gss-nistp521-sha512-*</c><c>This draft</c><c>MAY</c>
           <c>gss-curve25519-sha256-*</c><c>This draft</c><c>SHOULD</c>
           <c>gss-curve448-sha512-*</c><c>This draft</c><c>MAY</c>
       </texttable>


### PR DESCRIPTION
RFC 5656 uses "nistp256", "nistp384" and "nistp521" for the curves
so don't use the TLS aliases for those curves