### PR TITLE
Require zero check for CFRG curves

### DIFF
--- a/draft-ietf-curdle-gss-keyex-sha2.xml
+++ b/draft-ietf-curdle-gss-keyex-sha2.xml
@@ -180,7 +180,9 @@
         <xref target="RFC5656"/> apply here as well.</t>
 
         <t>For curve25519 and curve448 related computations see Section 6
-        of <xref target="RFC7748"/>.</t>
+        of <xref target="RFC7748"/>; implementations MUST check whether the
+        computed Diffie-Hellman shared secret is the all-zero value and
+        abort if so.</t>
 
         <t>This section defers to <xref target="RFC7546"/> as the source of
         information on GSS-API context establishment operations, Section 3


### PR DESCRIPTION
Eric Rescorla thinks the "MAY" language in Section 6 of RFC7748 is insufficient and we need to explicitly require the check. This language does that in a similar way to what has been done in the TLS RFC.